### PR TITLE
c9.io TEST configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.c9
 .DS_Store
 *.sublime-workspace
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,6 +12,6 @@ You will need access to the production server to complete this guide.
 6. `mysql` + `CREATE DATABASE freeukgenealogy;` - Log in to your local MySQL instance and create a database for the Craft CMS installation
 7. `mysql freeukgenealogy < "$( ls ./FreeUKGenealogy/craft/storage/backups/ | tail -n1 )"` - Import the most recent database backup
 8. `sudo a2enmod rewrite && sudo a2enmod ssl && sudo cp ./FreeUKGenealogy/etc/localhost/local.freeukgenealogy.conf /etc/apache2/sites-available && a2ensite local.freeukgenealogy && sudo apache2ctl restart` - Enable Apache2 mods, copy the site configuration, enable the site, and restart `apache2`
-9. `sudo echo -e "127.0.0.1\tfreeukgenealogy.local" > /etc/hosts` - Add an `/etc/hosts` directive for your local instance
+9. `sudo echo -e "\n\n# freeukgenealogy.org.uk\n127.0.0.1\tfreeukgenealogy.local" >> /etc/hosts` - Add an `/etc/hosts` directive for your local instance
 
 If everything worked as expected, you should now be able to browse to `https://freeukgenealogy.local/` to work on the site and manage code changes using `git`.

--- a/craft/plugins/sproutinvisiblecaptcha/services/SproutInvisibleCaptcha_TimeMethodService.php
+++ b/craft/plugins/sproutinvisiblecaptcha/services/SproutInvisibleCaptcha_TimeMethodService.php
@@ -23,7 +23,7 @@ class SproutInvisibleCaptcha_TimeMethodService extends BaseApplicationComponent 
 		// added to fileter spam words in message
 		$arr = array(
 			'href=',
-			'link='
+			'link=',
 			'url=',
 			'viagra',
 			'yourls.site'

--- a/etc/README.md
+++ b/etc/README.md
@@ -1,0 +1,26 @@
+# Environments
+
+Use the appropriate configuration for your environment:
+
+* **AWS** - Amazon Web Services instances
+* **c9.io** - TEST instances
+* **local** - Local development instances
+* **cms.freebmd.org.uk** - Hetzner hosting production instance
+
+## AWS
+
+TODO
+
+## c9.io
+
+Run the following command to replace 001-cloud9.conf with repository version (enforces username `preview`/password `preview` with HTTP basic auth):
+
+`rm /etc/apache2/sites-available/001-cloud9.conf && ln -s /home/ubuntu/workspace/etc/c9.io/001-cloud9.conf /etc/apache2/sites-available/001-cloud9.conf`
+
+## Local
+
+TODO
+
+## cms.freebmd.org.uk
+
+TODO

--- a/etc/c9.io/001-cloud9.conf
+++ b/etc/c9.io/001-cloud9.conf
@@ -1,0 +1,26 @@
+<VirtualHost *:8080>
+    DocumentRoot /home/ubuntu/workspace/public
+    ServerName https://${C9_HOSTNAME}:443
+
+    LogLevel info
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+    
+    <Directory /home/ubuntu/workspace/public>
+        Options Indexes FollowSymLinks
+        AllowOverride All
+
+	AuthType Basic
+	AuthName "Authentication Required"
+	AuthUserFile "/home/ubuntu/workspace/etc/c9.io/htpasswd"
+	Require valid-user
+
+	Order allow,deny
+	Allow from all
+
+    </Directory>
+</VirtualHost>
+
+ServerName https://${C9_HOSTNAME}
+# vim: syntax=apache ts=4 sw=4 sts=4 sr noet

--- a/etc/c9.io/htpasswd
+++ b/etc/c9.io/htpasswd
@@ -1,0 +1,2 @@
+preview:$apr1$ptq9E6NE$/D024lZUH5mknV62apGwi0
+


### PR DESCRIPTION
Includes replacement `001-cloud9.conf` apache2 configuration, u:`preview`/p:`preview` htpasswd file.